### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main # Change this to the name of your default branch, if different
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/BrodieSutherland/up-to-ynab/security/code-scanning/1](https://github.com/BrodieSutherland/up-to-ynab/security/code-scanning/1)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly define the permissions required for the workflow, limiting the `GITHUB_TOKEN` to the least privileges necessary. Since the workflow does not interact with repository contents or require write access, the permissions can be set to `contents: read`. This ensures that the workflow can read repository contents without granting unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
